### PR TITLE
Fix broken javascript src URLs in video HTML files.

### DIFF
--- a/Videos/03 - Embedding and Interactions/jsapi_embed_interactions_action.html
+++ b/Videos/03 - Embedding and Interactions/jsapi_embed_interactions_action.html
@@ -10,7 +10,7 @@
     <!-- Access the API & Load your JavaScript -->
     <script type='text/javascript'
         src='http://public.tableau.com/javascripts/api/tableau-2.min.js'></script>
-    <script type='text/javascript' src='jsapi_in_action.js'></script>
+    <script type='text/javascript' src='jsapi_embed_interactions_action.js'></script>
 </head>
 <body>
 	<div class='container'>

--- a/Videos/04 - Tips and Tricks/jsapi_tips_n_tricks.html
+++ b/Videos/04 - Tips and Tricks/jsapi_tips_n_tricks.html
@@ -7,7 +7,7 @@
 	<link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
 	<link href="bootstrap.css" rel="stylesheet" media="screen">
 	<script type="text/javascript" src="http://public.tableau.com/javascripts/api/tableau-2.min.js"></script>
-	<script type="text/javascript" src="jsapi_techniques.js"></script>
+	<script type="text/javascript" src="jsapi_tips_n_tricks.js"></script>
 </head>
 <body>
 	<div class='container'>

--- a/Videos/04 - Tips and Tricks/jsapi_tips_n_tricks_beginning.html
+++ b/Videos/04 - Tips and Tricks/jsapi_tips_n_tricks_beginning.html
@@ -7,7 +7,7 @@
 	<link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
 	<link href="bootstrap.css" rel="stylesheet" media="screen">
 	<script type="text/javascript" src="http://public.tableau.com/javascripts/api/tableau-2.min.js"></script>
-	<script type="text/javascript" src="jsapi_techniques_beginning.js"></script>
+	<script type="text/javascript" src="jsapi_tips_n_tricks_beginning.js"></script>
 </head>
 <body>
 	<div class='container'>


### PR DESCRIPTION
Noticed some of local javascript URLs weren't good when working through the video tutorials and updated them.